### PR TITLE
fix: 修改对于react-native-svg的依赖版本号的写法

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "react-native": ">=0.63.4",
     "react": "*",
-    "@react-native-oh-tpl/react-native-svg": ">= 13.14.0-0.0.3"
+    "@react-native-oh-tpl/react-native-svg": "^13.14.0-0.0.3"
   },
   "dependencies": {
     "prop-types": "^15.8.0",


### PR DESCRIPTION
# Summary
- 这个 PR 解决了Closes #1 
- 修改了对于依赖的react-native-svg的版本号的写法

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
