### PR TITLE
fix:修复因为依赖react-native-svg版本引发在安装时报错react-native-svg版本冲突问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "react-native": ">=0.63.4",
     "react": "*",
-    "@react-native-oh-tpl/react-native-svg": "^13.14.0-0.0.3"
+    "react-native-svg": ">= 13.14.0"
   },
   "dependencies": {
     "prop-types": "^15.8.0",


### PR DESCRIPTION
# Summary
- 这个 PR 解决了 close #4 
- 将package.json中的对于react-native-svg的依赖从原来的@react-native-on-tpl/react-native-svg改为react-naitve-svg解决 安装时报错问题

## Test Plan

下载依赖配置下载成功，无报错


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

